### PR TITLE
Remove Docker multi-staged building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the NodeJS image as builder
-FROM node:lts AS builder
+# Use the NodeJS v18 image
+FROM node:18
 
 # Create the workspace
 WORKDIR /usr/src/app
@@ -26,17 +26,9 @@ COPY .env .
 # Build the application
 RUN yarn build
 
-# The actual server, this builds the final image
-FROM node:lts
-
-# Create the workspace
-WORKDIR /usr/src/app
-
-# Copy the output of the builder
-COPY --from=builder /usr/src/app/.output ./.output
-
 # Start
 ENV HOST 0.0.0.0
 ENV PORT 80
+
 EXPOSE 80
 CMD ["node", ".output/server/index.mjs"]


### PR DESCRIPTION
This is to allow running the Prisma migrations with the same image.