### PR TITLE
chore(ci): disable running linting actions on a push event

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,7 +2,6 @@
 name: Linting
 on:
   - pull_request
-  - push
 
 jobs:
   build:


### PR DESCRIPTION
# chore(ci): disable running linting actions on a push event

<!--- ☝️ PR titel moet in de stijl van conventional commits (https://conventionalcommits.org) -->

## 🔗 Linked issue

#28 

<!-- Zorg dat er een open issue is en plaats het nummer hier (bijv. #123) -->

## ❓ Wat voor soort aanpassing?

<!-- Wat voor soort aanpassing brengt jouw code? Vink aan alle relevante opties. -->

- [ ] 📖 Documentatie (updates aan JSDoc of README)
- [x] 🐞 Bugfix (een non-breaking change dat een probleem oplost)
- [x] 👌 Enhancement (verbeterd een bestaande functionaliteit: oa. performance)
- [ ] ✨ Nieuwe feature (een non-breaking change dat functionaliteit toevoegt)
- [ ] ⚠️ Breaking change (fix of feature dat bestaande functionaliteiten verandert)

## 📚 Beschrijving

<!-- Beschrijf je aanpassing in detail -->
<!-- Waarom is deze aanpassing nodig? Wat probleem lost dit op? -->
<!-- Als het een open issue oplost, link het issue hier. Bijvoorbeeld "Resolves #1337" -->

The CI runs every check twice, as it's also ran on a push event. This is not needed for us, running on just PR events if enough. So we can disable the push event trigger.

## 📝 Checklist

<!-- Vink aan wanneer je het hebt gedaan. -->

- [x] Ik heb een issue gelinkt.
- [ ] Ik heb de wiki geüpdate gebaseerd op mijn aanpassingen.
