### PR TITLE
Set the origin correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ COPY tsconfig.json .
 # Generate the Prisma client
 RUN npx prisma generate
 
+# Set the auth origin, as this needs to be done on build time.
+# This is the public URL of Mijn Proteus, NOT Authentik.
+ENV AUTH_ORIGIN "https://mijn.proteuseretes.nl"
+
 # Build the application
 RUN yarn build
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
     },
   },
   auth: {
-    origin: "http://localhost:3000",
+    origin: process.env.AUTH_ORIGIN ?? "http://localhost:3000",
   },
   app: {
     head: {


### PR DESCRIPTION
# Set the origin for authentication

<!--- ☝️ PR titel moet in de stijl van conventional commits (https://conventionalcommits.org) -->

## 🔗 Linked issue

<!-- Zorg dat er een open issue is en plaats het nummer hier (bijv. #123) -->

## ❓ Wat voor soort aanpassing?

<!-- Wat voor soort aanpassing brengt jouw code? Vink aan alle relevante opties. -->

- [ ] 📖 Documentatie (updates aan JSDoc of README)
- [x] 🐞 Bugfix (een non-breaking change dat een probleem oplost)
- [ ] 👌 Enhancement (verbeterd een bestaande functionaliteit: oa. performance)
- [ ] ✨ Nieuwe feature (een non-breaking change dat functionaliteit toevoegt)
- [ ] ⚠️ Breaking change (fix of feature dat bestaande functionaliteiten verandert)

## 📚 Beschrijving

<!-- Beschrijf je aanpassing in detail -->
<!-- Waarom is deze aanpassing nodig? Wat probleem lost dit op? -->
<!-- Als het een open issue oplost, link het issue hier. Bijvoorbeeld "Resolves #1337" -->

The authentication module requires you to set the origin at build time. This PR adds the release origin to the Docker image.

## 📝 Checklist

<!-- Vink aan wanneer je het hebt gedaan. -->

- [ ] Ik heb een issue gelinkt.
- [ ] Ik heb de wiki geüpdate gebaseerd op mijn aanpassingen.
